### PR TITLE
add cURL fallback for git bash on Windows, add Python 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.cpp
 
 build/
+__pycache__/
 
 # folders
 saved_sessions/

--- a/packages/lifting/__init__.py
+++ b/packages/lifting/__init__.py
@@ -1,2 +1,2 @@
 from ._pose_estimator import *
-import utils
+from . import utils

--- a/packages/lifting/_pose_estimator.py
+++ b/packages/lifting/_pose_estimator.py
@@ -4,8 +4,8 @@ Created on Jul 13 16:20 2017
 
 @author: Denis Tome'
 """
+from . import utils
 import cv2
-import utils
 import numpy as np
 import tensorflow as tf
 

--- a/packages/lifting/utils/__init__.py
+++ b/packages/lifting/utils/__init__.py
@@ -8,5 +8,5 @@ from .prob_model import *
 from .draw import *
 from .cpm import *
 from .process import *
-import config
-import upright_fast
+from . import config
+from . import upright_fast

--- a/packages/lifting/utils/draw.py
+++ b/packages/lifting/utils/draw.py
@@ -6,9 +6,9 @@ Created on Mar 23 15:04 2017
 """
 import cv2
 import numpy as np
-from config import JOINT_DRAW_SIZE
-from config import LIMB_DRAW_SIZE
-from config import NORMALISATION_COEFFICIENT
+from .config import JOINT_DRAW_SIZE
+from .config import LIMB_DRAW_SIZE
+from .config import NORMALISATION_COEFFICIENT
 import matplotlib.pyplot as plt
 import math
 
@@ -31,7 +31,7 @@ def draw_limbs(image, pose_2d, visible):
 
     _NORMALISATION_FACTOR = int(math.floor(math.sqrt(image.shape[0] * image.shape[1] / NORMALISATION_COEFFICIENT)))
 
-    for oid in xrange(pose_2d.shape[0]):
+    for oid in range(pose_2d.shape[0]):
         for lid, (p0, p1) in enumerate(_LIMBS):
             if not (visible[oid][p0] and visible[oid][p1]):
                 continue

--- a/packages/lifting/utils/prob_model.py
+++ b/packages/lifting/utils/prob_model.py
@@ -185,7 +185,7 @@ class Prob3dPose:
         scale = a[:, :, 0]
         reestimate = scale > cap_scale
         m = self.mu * cap_scale
-        for i in xrange(scale.shape[0]):
+        for i in range(scale.shape[0]):
             if reestimate[i].sum() > 0:
                 ehat = e2[i:i + 1, 1:]
                 mhat = m[i:i + 1]

--- a/packages/lifting/utils/process.py
+++ b/packages/lifting/utils/process.py
@@ -4,6 +4,8 @@ Created on Mar 23 15:29 2017
 
 @author: Denis Tome'
 """
+from __future__ import division
+
 import os
 import json
 import numpy as np
@@ -43,7 +45,7 @@ def detect_objects_heatmap(heatmap):
     objects = np.zeros((num_objects, 2), dtype=np.int32)
     pidx = 0
     for (dy, dx) in slices:
-        pos = [(dy.start + dy.stop - 1) / 2, (dx.start + dx.stop - 1) / 2]
+        pos = [(dy.start + dy.stop - 1) // 2, (dx.start + dx.stop - 1) // 2]
         if heatmap[pos[0], pos[1]] > config.CENTER_TR:
             objects[pidx, :] = pos
             pidx += 1
@@ -114,7 +116,7 @@ def detect_parts_heatmaps(heatmaps, centers, size, num_parts=14):
     for oid, (yc, xc) in enumerate(centers):
         part_hmap = skimage.transform.resize(
             np.clip(heatmaps[oid], -1, 1), size)
-        for pid in xrange(num_parts):
+        for pid in range(num_parts):
             y, x = np.unravel_index(np.argmax(part_hmap[:, :, pid]), size)
             parts[oid, pid] = y + yc - size[0] // 2, x + xc - size[1] // 2
             visible[oid, pid] = np.mean(
@@ -252,11 +254,11 @@ def crop_image(image, obj_pose):
     Returns the cropped image and the offset that is used to update the joint
     positions.
     """
-    offset_left = int(obj_pose[0] - config.INPUT_SIZE / 2)
-    offset_up = int(obj_pose[1] - config.INPUT_SIZE / 2)
+    offset_left = int(obj_pose[0] - config.INPUT_SIZE // 2)
+    offset_up = int(obj_pose[1] - config.INPUT_SIZE // 2)
     # just for checking that it's inside the image
-    offset_right = int(image.shape[1] - obj_pose[0] - config.INPUT_SIZE / 2)
-    offset_bottom = int(image.shape[0] - obj_pose[1] - config.INPUT_SIZE / 2)
+    offset_right = int(image.shape[1] - obj_pose[0] - config.INPUT_SIZE // 2)
+    offset_bottom = int(image.shape[0] - obj_pose[1] - config.INPUT_SIZE // 2)
 
     pad_left, pad_right, pad_up, pad_bottom = 0, 0, 0, 0
     if offset_left < 0:

--- a/packages/lifting/utils/upright_fast.py
+++ b/packages/lifting/utils/upright_fast.py
@@ -84,7 +84,7 @@ def estimate_a_and_r_with_res(
     Ps_reshape = Ps.reshape(2 * points)
     w_reshape = w.reshape((frames, points * 2))
 
-    for i in xrange(check.size):
+    for i in range(check.size):
         c = check[i]
         r[0] = np.cos(c)
         r[1] = np.sin(c)
@@ -177,7 +177,7 @@ def estimate_a_and_r_with_res_weights(
     w_reshape = w.reshape((frames, points * 2))
     p_copy = np.empty_like(proj_e)
 
-    for i in xrange(check.size):
+    for i in range(check.size):
         c = check[i]
         r[0] = np.sin(c)
         r[1] = np.cos(c)
@@ -199,7 +199,7 @@ def estimate_a_and_r_with_res_weights(
             res[:, 2 * points] = scale_prior
         if weights.size != 0:
             res[:, :points * 2] *= weights
-        for j in xrange(frames):
+        for j in range(frames):
             p_copy[:] = proj_e
             p_copy[:, :points * 2] *= weights[j]
             a[i, :, j], comp_residual, _, _ = np.linalg.lstsq(
@@ -253,7 +253,7 @@ def pick_e(w, e, s0, camera_r=None, Lambda=None,
     Ps = np.empty((2, points))
 
     if weights.size == 0:
-        for i in xrange(charts):
+        for i in range(charts):
             if Lambda.size != 0:
                 a[i], r[i], score[i] = estimate_a_and_r_with_res(
                     w, e[i], s0[i], camera_r,
@@ -268,7 +268,7 @@ def pick_e(w, e, s0, camera_r=None, Lambda=None,
                     depth_reg, scale_prior)
     else:
         w2 = weights.reshape(weights.shape[0], -1)
-        for i in xrange(charts):
+        for i in range(charts):
             if Lambda.size != 0:
                 a[i], r[i], score[i] = estimate_a_and_r_with_res_weights(
                     w, e[i], s0[i], camera_r,

--- a/setup.sh
+++ b/setup.sh
@@ -3,9 +3,15 @@
 mkdir -p data/saved_sessions
 cd data/saved_sessions
 
+# fallback to curl if wget not available (e.g. git bash in Windows)
+WGET='wget'
+if ! [ -x "$(command -v git)" ]; then
+	WGET='curl -O'
+fi
+
 echo 'Downloading models...'
-wget http://visual.cs.ucl.ac.uk/pubs/liftingFromTheDeep/res/init_session.tar.gz
-wget http://visual.cs.ucl.ac.uk/pubs/liftingFromTheDeep/res/prob_model.tar.gz
+${WGET} http://visual.cs.ucl.ac.uk/pubs/liftingFromTheDeep/res/init_session.tar.gz
+${WGET} http://visual.cs.ucl.ac.uk/pubs/liftingFromTheDeep/res/prob_model.tar.gz
 
 echo 'Extracting models...'
 tar -xvzf init_session.tar.gz


### PR DESCRIPTION
In order to run the demo on Windows, I made the following modifications:

- the wget command in 'setup.sh' has been replaced with 'curl -O' if the former is not
  found to work on the base git bash on Windows.
- imports, integer division operations and xrange calls have been fixed to work on Python 3.

The demo has been successfully tested on Windows with `Python 3.5` and `Tensorflow GPU 1.3` and
Ubuntu 16.04 with `Python 2.7` and `Tensorflow CPU 1.3`.
